### PR TITLE
auth for cloud requires different params than generic auth

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ datasources:
       database: <my-edgedb-schema-name>
       tlsSecurity: strict
     secureJsonData:
-      cloudSecret: <my-instance-cloud-secret>
+      secretKey: <my-instance-cloud-secret>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ datasources:
     isDefault: true
     editable: false
     jsonData:
+      deployment: edgedb-cloud
       cloudInstance: <my-edge-db-instance-name>
       database: <my-edgedb-schema-name>
       tlsSecurity: strict

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ datasources:
     isDefault: true
     editable: false
     jsonData:
-      deployment: edgedb-cloud
       cloudInstance: <my-edge-db-instance-name>
       database: <my-edgedb-schema-name>
       tlsSecurity: strict

--- a/README.md
+++ b/README.md
@@ -11,16 +11,15 @@ For more information about backend plugins, refer to the documentation on [Grafa
 
 ## Installation
 
-Use Grafana 8.0 or higher is required for this plugin.  To install, follow
-instruction below to build the plugin and then copy the resulting `dist/`
-directory as `$GF_PATHS_PLUGINS/edgedb`.
+Use Grafana 8.0 or higher is required for this plugin.  To install,
+follow instruction below to build the plugin and then copy the
+resulting `dist/` directory as `$GF_PATHS_PLUGINS/edgedb`.
 
-This plugin is not signed yet, and Grafana will refuse to load it, unless
-explicitly configured to do so via
-the `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=edgedb` environment variable,
-or `allow_loading_unsigned_plugins = edgedb` in the `[plugins]` section in
-`grafana.ini`.
-
+This plugin is not signed yet, and Grafana will refuse to load it,
+unless explicitly configured to do so via the
+`GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=edgedb` environment
+variable, or `allow_loading_unsigned_plugins = edgedb` in the
+`[plugins]` section in `grafana.ini`.
 
 ## Building from source
 
@@ -54,7 +53,9 @@ A data source backend plugin consists of both frontend and backend components.
 
 ### Backend
 
-1. Update [Grafana plugin SDK for Go](https://grafana.com/docs/grafana/latest/developers/plugins/backend/grafana-plugin-sdk-for-go/) dependency to the latest minor version:
+1. Update [Grafana plugin SDK for
+Go](https://grafana.com/docs/grafana/latest/developers/plugins/backend/grafana-plugin-sdk-for-go/)
+dependency to the latest minor version:
 
    ```bash
    go get -u github.com/grafana/grafana-plugin-sdk-go
@@ -72,3 +73,70 @@ A data source backend plugin consists of both frontend and backend components.
    ```bash
    mage -l
    ```
+## Authentication
+
+### Local or self-hosted
+
+For a local or self-hosted EdgeDB instance your grafana datasource
+file will look like:
+
+```
+---
+apiVersion: 1
+
+datasources:
+  - name: Metrics (edgedb.com)
+    type: edgedb
+    uid: edgedb_site_metrics
+    access: proxy
+    isDefault: true
+    editable: false
+    jsonData:
+      host: <edgedb-hostname>
+      port: <edgedb-port-number>
+      user: <edgedb-metrics-user>
+      database: <edgedb-metrics-database>
+      tlsSecurity: <"strict"|"insecure"|"no_host_verification">
+      tlsCA: <optional root cert if self-signed>
+    secureJsonData:
+      password: <edgedb-metrics-users-password>
+```
+
+### EdgeDB Cloud
+
+The [edgedb-go](https://github.com/edgedb/edgedb-go) client library
+authenticates [EdgeDB SAAS hosted Cloud](https://www.edgedb.com/cloud)
+differntly than local or self-hosted.  The EdgeDB Cloud instances
+authenticate with a combination of an instance name and a cloud secret
+key.  These are obtained from the EdgeDB Cloud UI when you [create an
+instance](https://cloud.edgedb.com/org/edgedb/create-instance).
+
+The grafana datasource must indicate that the cloud authentication
+settings are in use.  A sample [grafana datasource
+file](https://grafana.com/docs/grafana/latest/datasources) is shown
+below.
+
+The EdgeDB connection uses TLS.  The server presents a certificate
+signed by a widely trusted root so the `tlsCA` parameter should not be
+needed.
+
+```
+---
+apiVersion: 1
+
+datasources:
+  - name: <My Instance> (edgedb cloud)
+    type: edgedb
+    uid: edgedb_site_metrics
+    access: proxy
+    isDefault: true
+    editable: false
+    jsonData:
+      cloudInstance: <my-edge-db-instance-name>
+      database: <my-edgedb-schema-name>
+      tlsSecurity: strict
+    secureJsonData:
+      cloudSecret: <my-instance-cloud-secret>
+```
+
+

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.3
 
 require (
-	github.com/edgedb/edgedb-go v0.14.4
+	github.com/edgedb/edgedb-go v0.16.0
 	github.com/grafana/grafana-plugin-sdk-go v0.190.0
 )
 
@@ -64,7 +64,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 // indirect
+	github.com/sigurn/crc16 v0.0.0-20240131213347-83fcde1e29d1 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/unknwon/bra v0.0.0-20200517080246-1e3013ecaff8 // indirect
 	github.com/unknwon/com v1.0.1 // indirect
@@ -83,13 +83,13 @@ require (
 	go.opentelemetry.io/otel/sdk v1.19.0 // indirect
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
+	golang.org/x/crypto v0.21.0 // indirect
+	golang.org/x/exp v0.0.0-20240318143956-a85f2c67cd81 // indirect
+	golang.org/x/mod v0.16.0 // indirect
+	golang.org/x/net v0.22.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/tools v0.14.0 // indirect
+	golang.org/x/tools v0.19.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230731193218-e0aa005b6bdf // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230731193218-e0aa005b6bdf // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/edgedb/edgedb-go v0.14.4 h1:gUhZWqAJeQd7kzuRHHBokxNhZDwoZqPJ1yC0LoMVRuw=
 github.com/edgedb/edgedb-go v0.14.4/go.mod h1:i0xx75FwGtei0CUoax9Cd1B6lr6yewTNw/5QQmR9NMA=
+github.com/edgedb/edgedb-go v0.16.0 h1:mMSSYCqnMVBBucSNbJlRLMIJLpS6kg/7fD0yNDagi/o=
+github.com/edgedb/edgedb-go v0.16.0/go.mod h1:J+llluepGAi/rIPNcUgIFEedCCISLKFG+VUEWnBhIqE=
 github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027 h1:1L0aalTpPz7YlMxETKpmQoWMBkeiuorElZIXoNmgiPE=
 github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
@@ -199,6 +201,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 h1:aQKxg3+2p+IFXXg97McgDGT5zcMrQoi0EICZs8Pgchs=
 github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3/go.mod h1:9/etS5gpQq9BJsJMWg1wpLbfuSnkm8dPF6FdW2JXVhA=
+github.com/sigurn/crc16 v0.0.0-20240131213347-83fcde1e29d1 h1:NVK+OqnavpyFmUiKfUMHrpvbCi2VFoWTrcpI7aDaJ2I=
+github.com/sigurn/crc16 v0.0.0-20240131213347-83fcde1e29d1/go.mod h1:9/etS5gpQq9BJsJMWg1wpLbfuSnkm8dPF6FdW2JXVhA=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
@@ -274,9 +278,13 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
+golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/exp v0.0.0-20240318143956-a85f2c67cd81 h1:6R2FC06FonbXQ8pK11/PDFY6N6LWlf9KlzibaCapmqc=
+golang.org/x/exp v0.0.0-20240318143956-a85f2c67cd81/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -285,6 +293,8 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
+golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -295,6 +305,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.22.0 h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc=
+golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
 golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
@@ -323,6 +335,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
@@ -339,6 +353,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.14.0 h1:jvNa2pY0M4r62jkRQ6RwEZZyPcymeL9XZMLBbV7U2nc=
 golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
+golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
+golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/edgedb/edgedb-go v0.13.5 h1:Jxd3E5QJRvNhklYtaOoXEu6lIf2hqNbA036UL3DFQoc=
-github.com/edgedb/edgedb-go v0.13.5/go.mod h1:e//omVkE0RjyJvzRizoIhYDXz8FL9z/2cfGKORbDbSk=
 github.com/edgedb/edgedb-go v0.14.4 h1:gUhZWqAJeQd7kzuRHHBokxNhZDwoZqPJ1yC0LoMVRuw=
 github.com/edgedb/edgedb-go v0.14.4/go.mod h1:i0xx75FwGtei0CUoax9Cd1B6lr6yewTNw/5QQmR9NMA=
 github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027 h1:1L0aalTpPz7YlMxETKpmQoWMBkeiuorElZIXoNmgiPE=
@@ -277,8 +275,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20230206171751-46f607a40771 h1:xP7rWLUr1e1n2xkK5YB4LI0hPEy3LJC6Wk+D4pGlOJg=
-golang.org/x/exp v0.0.0-20230206171751-46f607a40771/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -287,8 +283,6 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
-golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -310,9 +304,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -328,14 +321,10 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
-golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -348,8 +337,6 @@ golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.10.0 h1:tvDr/iQoUqNdohiYm0LmmKcBk+q86lb9EprIUFhHHGg=
-golang.org/x/tools v0.10.0/go.mod h1:UJwyiVBsOA2uwvK/e5OY3GTpDUJriEd+/YlqAwLPmyM=
 golang.org/x/tools v0.14.0 h1:jvNa2pY0M4r62jkRQ6RwEZZyPcymeL9XZMLBbV7U2nc=
 golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -43,7 +43,7 @@ func NewEdgeDBDatasource(
 		return nil, err
 	}
 
-	msg :=fmt.Sprintf("connecting to edgedb server using: %s, %#v",
+	msg :=fmt.Sprintf("connecting to edgedb server using: instance=\"%s\", %#v",
 		cloudInstance, opts)
 	log.DefaultLogger.Debug(msg)
 

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -46,7 +46,7 @@ func NewEdgeDBDatasource(
 	log.DefaultLogger.Debug(
 		fmt.Sprintf("connecting to edgedb server using: %#v", opts))
 	var client *edgedb.Client
-	if cloudInstance =="" {
+	if cloudInstance == "" {
 		// non cloud
 		client, err = edgedb.CreateClient(ctx, opts)
 	} else {

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -45,14 +45,9 @@ func NewEdgeDBDatasource(
 
 	log.DefaultLogger.Debug(
 		fmt.Sprintf("connecting to edgedb server using: %#v", opts))
-	var client *edgedb.Client
-	if cloudInstance == "" {
-		// non cloud
-		client, err = edgedb.CreateClient(ctx, opts)
-	} else {
-		// for cloud, the DSN parser accepts an instance
-		client, err = edgedb.CreateClientDSN(ctx, cloudInstance, opts)
-	}
+
+	// the client config options accepts a cloud instance as DSN if present
+	client, err := edgedb.CreateClientDSN(ctx, cloudInstance, opts)
 	if err != nil {
 		log.DefaultLogger.Error(
 			fmt.Sprintf("could not connect: %q", err.Error()))

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -299,10 +299,7 @@ func getOptions(s *backend.DataSourceInstanceSettings) (edgedb.Options, error) {
 
 func getCloudOptions(s *backend.DataSourceInstanceSettings) (map[string]string, error) {
 	var settings struct {
-		Cloud struct {
-			Instance    string `json:instance`
-			SecretKey   string `json:secret`
-		}
+		Instance    string `json:"cloudInstance"`
 		Database    string `json:"database"`
 		TlsCA       string `json:"tlsCA"`
 		TlsSecurity string `json:"tlsSecurity"`
@@ -317,7 +314,7 @@ func getCloudOptions(s *backend.DataSourceInstanceSettings) (map[string]string, 
 	// no need to validate here ..
 	// the edgedb-go client will validate and fail if not
 	cloudOptions["EDGEDB_INSTANCE"] = settings.Cloud.Instance
-	cloudOptions["EDGEDB_SECRET_KEY"] = settings.Cloud.SecretKey
+	cloudOptions["EDGEDB_SECRET_KEY"] = s.DecryptedSecureJSONData["cloudSecret"]
 
 	if settings.TlsSecurity == "" {
 		settings.TlsSecurity = "strict"

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -43,8 +43,9 @@ func NewEdgeDBDatasource(
 		return nil, err
 	}
 
-	log.DefaultLogger.Debug(
-		fmt.Sprintf("connecting to edgedb server using: %#v", opts))
+	msg :=fmt.Sprintf("connecting to edgedb server using: %s, %#v",
+		cloudInstance, opts)
+	log.DefaultLogger.Debug(msg)
 
 	// the client config options accepts a cloud instance as DSN if present
 	client, err := edgedb.CreateClientDSN(ctx, cloudInstance, opts)
@@ -225,9 +226,7 @@ func getOptions(s *backend.DataSourceInstanceSettings) (edgedb.Options, string, 
 	}
 
 	var port int
-	if settings.Port == "" {
-		port = 5656
-	} else {
+	if settings.Port != "" {
 		port, err = strconv.Atoi(settings.Port)
 		if err != nil {
 			return edgedb.Options{}, "", err

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -254,7 +254,7 @@ func getOptions(s *backend.DataSourceInstanceSettings) (edgedb.Options, string, 
 			SecurityMode: edgedb.TLSSecurityMode(settings.TlsSecurity),
 		},
 		// below for edgedb cloud
-		SecretKey: s.DecryptedSecureJSONData["cloudSecret"],
+		SecretKey: s.DecryptedSecureJSONData["secretKey"],
 	}
 	return opts, settings.Instance, nil
 }

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -52,19 +52,22 @@ func NewEdgeDBDatasource(
 			return nil, err
 		}
 
-		msg := fmt.Sprintf("connecting to edgedb server using: %#v", cloudOptions)
+		msg := fmt.Sprintf("connecting to edgedb cloud instance using: %#v",
+			cloudOptions)
 		log.DefaultLogger.Debug(msg)
-		// client expects all struct fields OR all env
+		// do not mix config and env
+		// edge cloud client expects ALL config struct values -or- ALL env vars
 		for key, value := range cloudOptions {
 			os.Setenv(key, value)
 		}
 		client, err = edgedb.CreateClient(ctx, edgedb.Options{})
 		if err != nil {
-			msg := fmt.Sprintf("could not connect to cloud: %q", err.Error())
+			msg := fmt.Sprintf("could not connect to edgedb cloud instance: %q",
+				err.Error())
 			log.DefaultLogger.Error(msg)
 			return nil, err
 		}
-	case "plugin":
+	case "generic":
 		// non-cloud is default
 		opts, err := getOptions(&settings)
 		if err != nil {
@@ -250,7 +253,7 @@ func getDeploymentType(s *backend.DataSourceInstanceSettings) (string, error) {
 		return "", nil
 	}
 	if dataSource.DeploymentType == "" {
-		dataSource.DeploymentType = "plugin"
+		dataSource.DeploymentType = "generic"
 	}
 	return dataSource.DeploymentType, nil
 }

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"errors"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"time"
-	
+
 	"github.com/edgedb/edgedb-go"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -302,10 +302,10 @@ func getOptions(s *backend.DataSourceInstanceSettings) (edgedb.Options, error) {
 
 func getCloudOptions(s *backend.DataSourceInstanceSettings) (map[string]string, error) {
 	var settings struct {
-		Instance    string `json:"cloudInstance"`
-		Database    string `json:"database"`
-		TlsCA       string `json:"tlsCA"`
-		TlsSecurity string `json:"tlsSecurity"`
+		CloudInstance string `json:"cloudInstance"`
+		Database      string `json:"database"`
+		TlsCA         string `json:"tlsCA"`
+		TlsSecurity   string `json:"tlsSecurity"`
 	}
 
 	cloudOptions := map[string]string{}
@@ -316,19 +316,19 @@ func getCloudOptions(s *backend.DataSourceInstanceSettings) (map[string]string, 
 	// for cloud, these two are required
 	// no need to validate here ..
 	// the edgedb-go client will validate and fail if not
-	cloudOptions["EDGEDB_INSTANCE"] = settings.Cloud.Instance
+	cloudOptions["EDGEDB_INSTANCE"] = settings.CloudInstance
 	cloudOptions["EDGEDB_SECRET_KEY"] = s.DecryptedSecureJSONData["cloudSecret"]
 
 	if settings.TlsSecurity == "" {
 		settings.TlsSecurity = "strict"
 	}
 	cloudOptions["EDGEDB_CLIENT_TLS_SECURITY"] = settings.TlsSecurity
-	
+
 	if settings.Database != "" {
 		cloudOptions["EDGEDB_DATABASE"] = settings.Database
 	}
 	if settings.TlsCA != "" {
 		cloudOptions["EDGEDB_TLS_CA"] = settings.TlsCA
 	}
-	return cloudOptions, nil 
+	return cloudOptions, nil
 }

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -186,7 +186,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             }
             value={secureJsonData.password || ''}
             label="Password"
-            placeholder="Password"
+            placeholder=""
             labelWidth={6}
             inputWidth={20}
             onReset={this.onResetPasssword}

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -46,6 +46,15 @@ export class ConfigEditor extends PureComponent<Props, State> {
     onOptionsChange({ ...options, jsonData });
   };
 
+  onCloudInstanceChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+    const jsonData = {
+      ...options.jsonData,
+      cloudInstance: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
   onTLSCAChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onOptionsChange, options } = this.props;
     const jsonData = {
@@ -77,6 +86,16 @@ export class ConfigEditor extends PureComponent<Props, State> {
     });
   };
 
+  onSecretKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+    onOptionsChange({
+      ...options,
+      secureJsonData: {
+        secretKey: event.target.value,
+      },
+    });
+  };
+
   onResetPasssword = () => {
     const { onOptionsChange, options } = this.props;
     onOptionsChange({
@@ -88,6 +107,21 @@ export class ConfigEditor extends PureComponent<Props, State> {
       secureJsonData: {
         ...options.secureJsonData,
         password: '',
+      },
+    });
+  };
+
+  onResetSecretKey = () => {
+    const { onOptionsChange, options } = this.props;
+    onOptionsChange({
+      ...options,
+      secureJsonFields: {
+        ...options.secureJsonFields,
+        secretKey: false,
+      },
+      secureJsonData: {
+        ...options.secureJsonData,
+        secretKey: '',
       },
     });
   };
@@ -129,6 +163,15 @@ export class ConfigEditor extends PureComponent<Props, State> {
           />
 
           <FormField
+            label="Cloud Instance"
+            labelWidth={6}
+            inputWidth={20}
+            onChange={this.onCloudInstanceChange}
+            value={jsonData.cloudInstance || ''}
+            placeholder="org/name"
+          />
+
+          <FormField
             label="User"
             labelWidth={6}
             inputWidth={20}
@@ -148,6 +191,19 @@ export class ConfigEditor extends PureComponent<Props, State> {
             inputWidth={20}
             onReset={this.onResetPasssword}
             onChange={this.onPasswordChange}
+          />
+
+          <SecretFormField
+            isConfigured={
+              (secureJsonFields && secureJsonFields.secretKey) as boolean
+            }
+            value={secureJsonData.secretKey || ''}
+            label="Cloud Secret"
+            placeholder="<secret>"
+            labelWidth={6}
+            inputWidth={20}
+            onReset={this.onResetSecretKey}
+            onChange={this.onSecretKeyChange}
           />
 
           <Switch

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -140,7 +140,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             inputWidth={20}
             onChange={this.onHostChange}
             value={jsonData.host || ''}
-            placeholder="127.0.0.1"
+            placeholder=""
           />
 
           <FormField
@@ -150,7 +150,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             inputWidth={20}
             onChange={this.onPortChange}
             value={jsonData.port || ''}
-            placeholder="5656"
+            placeholder=""
           />
 
           <FormField
@@ -159,7 +159,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             inputWidth={20}
             onChange={this.onDatabaseChange}
             value={jsonData.database || ''}
-            placeholder="edgedb"
+            placeholder=""
           />
 
           <FormField
@@ -168,7 +168,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             inputWidth={20}
             onChange={this.onCloudInstanceChange}
             value={jsonData.cloudInstance || ''}
-            placeholder="org/name"
+            placeholder=""
           />
 
           <FormField
@@ -177,7 +177,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             inputWidth={20}
             onChange={this.onUserChange}
             value={jsonData.user || ''}
-            placeholder="edgedb"
+            placeholder=""
           />
 
           <SecretFormField
@@ -199,7 +199,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             }
             value={secureJsonData.secretKey || ''}
             label="Cloud Secret"
-            placeholder="<secret>"
+            placeholder=""
             labelWidth={6}
             inputWidth={20}
             onReset={this.onResetSecretKey}

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,5 +56,5 @@ export interface Options extends DataSourceJsonData {
 
 export interface SecureJsonData {
   password?: string;
-  cloudSecret?: string;
+  secretKey?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,5 +56,5 @@ export interface Options extends DataSourceJsonData {
 
 export interface SecureJsonData {
   password?: string;
-  cloudSecret?:string;
+  cloudSecret?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface Options extends DataSourceJsonData {
   port?: string;
   user?: string;
   database?: string;
-  instance?: string;
+  cloudInstance?: string;
   tlsCA?: string;
   tlsSecurity?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,10 +49,12 @@ export interface Options extends DataSourceJsonData {
   port?: string;
   user?: string;
   database?: string;
+  instance?: string;
   tlsCA?: string;
   tlsSecurity?: string;
 }
 
 export interface SecureJsonData {
   password?: string;
+  cloudSecret?:string;
 }


### PR DESCRIPTION
Generic auth for local or not-edge cloud uses Host, Port, User, Password.
EgedDB Cloud uses cloud instance and cloud secret key - passed as env vars.
Create a new configuration option for cloud, and authenticate it
Typicall ds.yaml will look like:
```--
apiVersion: 1

datasources:
  - name: Metrics (edgedb.com)
    type: edgedb
    uid: edgedb_site_metrics
    access: proxy
    isDefault: true
    editable: false
    jsonData:
      cloudInstance: $EDGEDB_CLOUD_INSTANCE
      database: $EDGEDB_DATABASE
      tlsSecurity: strict
    secureJsonData:
      cloudSecret: $EDGEDB_CLOUD_SECRET
robert@edgedb:~/dev/infra/devops/services/grafana$ 
``` 